### PR TITLE
VEI-225: Create Audit Trail for the NETP Declaration Signing

### DIFF
--- a/app/controllers/clientDeclarationJourney/ClientDeclarationController.scala
+++ b/app/controllers/clientDeclarationJourney/ClientDeclarationController.scala
@@ -86,7 +86,7 @@ class ClientDeclarationController @Inject()(
                   auditService.sendAudit(
                     declarationSigningAuditType = CreateClientDeclaration,
                     result = SubmissionResult.Success,
-                    submittedDeclarationPageBody = view(form, waypoints, intermediaryName, clientCompanyName).body
+                    submittedDeclarationPageBody = view(form.fill(value), waypoints, clientCompanyName, intermediaryName).body
                   )
                   for {
                     updatedAnswers <- Future.fromTry(request.userAnswers.set(ClientDeclarationPage, value))
@@ -99,7 +99,7 @@ class ClientDeclarationController @Inject()(
                   auditService.sendAudit(
                     declarationSigningAuditType = CreateClientDeclaration,
                     result = SubmissionResult.Failure,
-                    submittedDeclarationPageBody = view(form, waypoints, intermediaryName, clientCompanyName).body
+                    submittedDeclarationPageBody = view(form.fill(value), waypoints, clientCompanyName, intermediaryName).body
                   )
                   logger.error(s"Unexpected result on registration creation submission: ${error.body}")
                   Redirect(ErrorSubmittingRegistrationPage.route(waypoints)).toFuture


### PR DESCRIPTION
After QA testing, this PR is to correct the clientCompanyName and IntermediaryName being called in the wrong order and for the audit to include that the checkbox is "checked"